### PR TITLE
Remove deprecated Gem::Specification#has_rdoc=

### DIFF
--- a/cssmin.gemspec
+++ b/cssmin.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split($/)
   s.test_files   = s.files.grep(%r{^(test|spec|features)/})
   s.require_path = 'lib'
-  s.has_rdoc     = true
 
   s.required_ruby_version = '>= 1.8.6'
 

--- a/cssmin.gemspec
+++ b/cssmin.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name     = 'cssmin'
-  s.version  = '1.0.3'
+  s.version  = '1.0.4'
   s.author   = 'Ryan Grove'
   s.email    = 'ryan@wonko.com'
   s.homepage = 'https://github.com/rgrove/cssmin/'


### PR DESCRIPTION
[#has_rdoc=](https://www.rubydoc.info/github/rubygems/rubygems/Gem%2FSpecification:has_rdoc) has been deprecated. This minor change lets us remove a spurious warning from sbn's build.